### PR TITLE
Fix basic file upload functionality -> ElementHandle#set_input_files

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,9 @@ use std::{
     path::{Path, PathBuf, MAIN_SEPARATOR}
 };
 
-const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+// const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+const DRIVER_VERSION: &str = "1.12.2";
+const NEXT: &str = "";
 
 fn main() {
     let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
@@ -79,10 +81,9 @@ fn url(platform: PlaywrightPlatform) -> String {
     //    .contains("next")
     //    .then(|| "/next")
     //    .unwrap_or_default();
-    let next = "/next";
     format!(
         "https://playwright.azureedge.net/builds/driver{}/playwright-{}-{}.zip",
-        next, DRIVER_VERSION, platform
+        NEXT, DRIVER_VERSION, platform
     )
 }
 

--- a/src/imp/utils.rs
+++ b/src/imp/utils.rs
@@ -228,14 +228,14 @@ pub struct PdfMargins<'a, 'b, 'c, 'd> {
 #[derive(Debug, Serialize, PartialEq)]
 pub struct File {
     pub name: String,
-    pub mime: String,
+    pub mimeType: String,
     pub buffer: String
 }
 
 impl File {
-    pub fn new(name: String, mime: String, body: &[u8]) -> Self {
+    pub fn new(name: String, mimeType: String, body: &[u8]) -> Self {
         let buffer = base64::encode(body);
-        Self { name, mime, buffer }
+        Self { name, mimeType, buffer }
     }
 }
 /// Browser distribution channel.


### PR DESCRIPTION
# Why? 

Changes made to address this issue https://github.com/octaltree/playwright-rust/issues/24

I also ran into a second issue half way through.  The video file I was trying to upload would only partially upload and then stop.   

# How?

I fixed the first issue by modifying the File struct in utils.rs to call `mime`  `mimeType` which, although breaking Rust naming conventions, ensures the driver is receiving the attribute name in the form it expects.

After fixing that, I found the upload was still not working correctly unto completion (specifically trying a file upload on Bitchute).  To fix this issue I updated the playwright driver version.  Current version is 1.11.0, which was upgraded to 1.12.2 to solve that issue.  Trying to upgrade to higher versions (I tried 1.16 and 1.19) breaks the code because no "objects" are returned to the Context struct from the driver process stdout.

# Tests

No tests were added and I did not fix the file_chooser test.  

Before you test out the code yourself it is important to to delete the previous driver folder which is located at `~/.cache/ms-playwright/playwright-rust/driver` , at least on Linux machines.  