### PR TITLE
Add request event handling on BrowserContext

### DIFF
--- a/src/api/browser_context.rs
+++ b/src/api/browser_context.rs
@@ -1,6 +1,6 @@
 pub use crate::imp::browser_context::EventType;
 use crate::{
-    api::{Browser, Page},
+    api::{Browser, Page, request::Request},
     imp::{
         browser_context::{BrowserContext as Impl, Evt},
         core::*,
@@ -219,7 +219,7 @@ impl BrowserContext {
     // service_workers
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Event {
     // BackgroundPage for chromium persistent
     // ServiceWorker
@@ -242,14 +242,18 @@ pub enum Event {
     /// ]);
     /// console.log(await newPage.evaluate('location.href'));
     /// ```
-    Page(Page)
+    Page(Page),
+    /// Emitted when a page issues a request. The request object is read-only. In order to intercept and mutate requests, see
+    /// [`method: Page.route`] or [`method: BrowserContext.route`].
+    Request(Request),
 }
 
 impl From<Evt> for Event {
     fn from(e: Evt) -> Event {
         match e {
             Evt::Close => Event::Close,
-            Evt::Page(w) => Event::Page(Page::new(w))
+            Evt::Page(w) => Event::Page(Page::new(w)),
+            Evt::Request(w) => Event::Request(Request::new(w)),
         }
     }
 }

--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -16,7 +16,7 @@ use crate::{
 ///
 /// If request gets a 'redirect' response, the request is successfully finished with the 'requestfinished' event, and a new
 /// request is  issued to a redirected url.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Request {
     inner: Weak<Impl>
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,9 @@ use std::{
     path::{Path, PathBuf, MAIN_SEPARATOR}
 };
 
-const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+// const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+const DRIVER_VERSION: &str = "1.12.2";
+const NEXT: &str = "";
 
 fn main() {
     let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
@@ -79,10 +81,9 @@ fn url(platform: PlaywrightPlatform) -> String {
     //    .contains("next")
     //    .then(|| "/next")
     //    .unwrap_or_default();
-    let next = "/next";
     format!(
         "https://playwright.azureedge.net/builds/driver{}/playwright-{}-{}.zip",
-        next, DRIVER_VERSION, platform
+        NEXT, DRIVER_VERSION, platform
     )
 }
 

--- a/src/imp/utils.rs
+++ b/src/imp/utils.rs
@@ -228,14 +228,14 @@ pub struct PdfMargins<'a, 'b, 'c, 'd> {
 #[derive(Debug, Serialize, PartialEq)]
 pub struct File {
     pub name: String,
-    pub mime: String,
+    pub mimeType: String,
     pub buffer: String
 }
 
 impl File {
-    pub fn new(name: String, mime: String, body: &[u8]) -> Self {
+    pub fn new(name: String, mimeType: String, body: &[u8]) -> Self {
         let buffer = base64::encode(body);
-        Self { name, mime, buffer }
+        Self { name, mimeType, buffer }
     }
 }
 /// Browser distribution channel.


### PR DESCRIPTION
# Description 

This is a small fix for handling request events.  Request events come in through the BrowserContext object on the `subscribe_event()` function but the current rust code is expecting it on the Page object which cannot receive those events based on the current implementation.

For reference we can look at how [playwright-java](https://github.com/microsoft/playwright-java) handles these events (in the BrowserContextImpl.java and PageImpl.java files).  I think we are forced to do it this way based on what the playwright driver is sending to us, though I'm not 100% sure since I'm still learning this codebase.     

# My changes
I added request event handling to the imp/BrowserContext.rs class and updated all related files needed to catch and rely the event.  

# Warning 
This contains code from another pull request that updates the driver version (see PR #26).     

