### PR TITLE
Add mac arm support by upgrading playwright's version to 1.25.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playwright"
-version = "0.0.20"
+version = "0.0.21"
 authors = ["octaltree <octaltree@gmail.com>"]
 description = "Playwright port to Rust"
 license = "MIT OR Apache-2.0"

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf, MAIN_SEPARATOR}
 };
 
-const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+const DRIVER_VERSION: &str = "1.25.1";
 
 fn main() {
     let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
@@ -75,11 +75,11 @@ fn check_size(p: &Path) {
 fn download(_url: &str, dest: &Path) { File::create(dest).unwrap(); }
 
 fn url(platform: PlaywrightPlatform) -> String {
-    // let next = DRIVER_VERSION
-    //    .contains("next")
-    //    .then(|| "/next")
-    //    .unwrap_or_default();
-    let next = "/next";
+    let next = DRIVER_VERSION
+       .contains("next")
+       .then(|| "/next")
+       .unwrap_or_default();
+    // let next = "/next";
     format!(
         "https://playwright.azureedge.net/builds/driver{}/playwright-{}-{}.zip",
         next, DRIVER_VERSION, platform


### PR DESCRIPTION
Tested locally by running `cargo run -- install firefox` and `cargo run -- ff google.com`.

Installing the driver would fail on 1.11.0-1620331022000 because the m1 platform wasn't supported back then.

Let me know if there's something else you'd like done to get this merged to master.

Solves https://github.com/octaltree/playwright-rust/issues/27.