### PR TITLE
fix select_option and type_args macro

### DIFF
--- a/src/imp/element_handle.rs
+++ b/src/imp/element_handle.rs
@@ -433,6 +433,7 @@ pub(crate) struct SelectOptionArgs {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) enum Opt {
     Value(String),
     Index(usize),

--- a/src/imp/frame.rs
+++ b/src/imp/frame.rs
@@ -688,7 +688,8 @@ pub enum FrameState {
 
 macro_rules! type_args {
     ($t:ident, $f:ident) => {
-        #[derive(Serialize)]
+        #[skip_serializing_none]
+        #[derive(Serialize, Default)]
         #[serde(rename_all = "camelCase")]
         pub(crate) struct $t<'a, 'b> {
             selector: &'a str,


### PR DESCRIPTION
`page.select_option_builder` and `page.press_builder` didn't work at all before those changes.