### PR TITLE
feat: update playwright version to 1.13.0

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf, MAIN_SEPARATOR}
 };
 
-const DRIVER_VERSION: &str = "1.11.0-1620331022000";
+const DRIVER_VERSION: &str = "1.13.0";
 
 fn main() {
     let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
@@ -12,8 +12,8 @@ fn main() {
     let platform = PlaywrightPlatform::default();
     fs::write(out_dir.join("platform"), platform.to_string()).unwrap();
     download(&url(platform), &dest);
-    println!("cargo:rerun-if-changed=src/build.rs");
-    println!("cargo:rustc-env=SEP={}", MAIN_SEPARATOR);
+    println!("cargo::rerun-if-changed=src/build.rs");
+    println!("cargo::rustc-env=SEP={}", MAIN_SEPARATOR);
 }
 
 #[cfg(all(not(feature = "only-for-docs-rs"), not(unix)))]
@@ -75,14 +75,9 @@ fn check_size(p: &Path) {
 fn download(_url: &str, dest: &Path) { File::create(dest).unwrap(); }
 
 fn url(platform: PlaywrightPlatform) -> String {
-    // let next = DRIVER_VERSION
-    //    .contains("next")
-    //    .then(|| "/next")
-    //    .unwrap_or_default();
-    let next = "/next";
     format!(
-        "https://playwright.azureedge.net/builds/driver{}/playwright-{}-{}.zip",
-        next, DRIVER_VERSION, platform
+        "https://playwright.azureedge.net/builds/driver/playwright-{}-{}.zip",
+        DRIVER_VERSION, platform
     )
 }
 

--- a/tests/devices/mod.rs
+++ b/tests/devices/mod.rs
@@ -72,7 +72,7 @@ async fn has_touch(page: &Page) -> bool {
 }
 
 async fn check_user_agent(page: &Page, port: u16) {
-    let user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1";
+    let user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.2 Mobile/15E148 Safari/604.1";
     assert_eq!(
         page.eval::<String>("() => navigator.userAgent")
             .await


### PR DESCRIPTION
## Problem
Hey folks, I am currently using `MacOS` operating system and then playwright version `1.11` is not support browsers for apple silicon machines. I was getting following error when I try install browsers. Also this PR related with #27
```
foo@bar:~/playwright-rust$ target/debug/playwright install
Failed to install browsers
Error: Failed to download chromium, caused by
Error: ERROR: Playwright does not support chromium on mac14-arm64
    at Object.assert (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/utils.js:86:15)
    at Registry.downloadURL (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/registry.js:346:17)
    at Object.downloadBrowserWithProgressBar (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/browserFetcher.js:84:26)
    at async validateCache (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:129:9)
    at async Object.installBrowsersWithProgressBar (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:80:9)
    at async Object.installBrowsers (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/driver.js:93:5)
    at async Command.<anonymous> (/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/cli.js:108:9)
``` 

## PR
In this PR, I updated playwright version to `1.13.0`, this version compatible with this project. I tried so many versions (like a latest version `1.43`) but I could not solve the following error on tests
```
---- imp::browser_context::tests::storage_state stdout ----
thread 'imp::browser_context::tests::storage_state' panicked at src/imp/browser_context.rs:307:62:
called `Result::unwrap()` on an `Err` value: InitializationError
```
It seems, `playwright-rust` could not parse incoming json data from `/Users/foo/Library/Caches/ms-playwright/playwright-rust/driver/package/cli.js run-driver`. As I understand, new versions of `playwright` does not serve this data

Also I updated `build.rs` file cause of `cargo:` notation is not available on new rust versions, here is the reference
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script

## Tests
Following tests are fails, I got timeout error when I run tests
- chromium_devices
- chromium_page
- connect_over_cdp
- firefox_devices
- firefox_page

```
thread 'chromium_devices' panicked at tests/devices/mod.rs:87:32:
called `Result::unwrap()` on an `Err` value: Timeout
```

## Conclusion
I am still working on this PR, I will update this PR when tests are succeeded, maybe we can work on it together @octaltree 